### PR TITLE
Fix missing comma in lighttpd config

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@ ssl.openssl.ssl-conf-cmd = (
 )
 
 var.response_header_policy = (
-  "strict-transport-security" =&gt; "max-age=63072000; includeSubDomains; preload"
+  "strict-transport-security" =&gt; "max-age=63072000; includeSubDomains; preload",
   "content-security-policy" =&gt; "default-src https:",
   "x-frame-options" =&gt; "DENY",
   "x-content-type-options" =&gt; "nosniff",


### PR DESCRIPTION
The policy was missing a comma, resulting in lighttpd failing to start.