### PR TITLE
Use lighttpd TLS defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@ setenv.set-response-header += var.response_header_policy
         <br />Using IIS? Check out <a href="https://www.nartac.com/Products/IISCrypto/Default.aspx">IIS Crypto</a>. Other software like Zeus, Tomcat? Detailed info? Read the <a href="https://wiki.mozilla.org/Security/Server_Side_TLS">Mozilla Page</a>.
               <br />Cipherlist.eu is made by <a href="https://raymii.org">Remy van Elst (Raymii.org)</a> &amp; <a href="http://tnx.nl">Juerd</a> (not the server admin, suggestions to Remy or as pull request) after the idea spawned at a <a href="https://privacycafe.nl/">Privacy Cafe</a> at <a href="https://revspace.nl">Revspace</a>.
 		    The image is Public Domain from <a href="https://commons.wikimedia.org/wiki/File:Heart-padlock.svg">here</a>.
-		    Feedback <a href="https://github.com/revspace/cipherlist.eu/issues">here please</a>. Source code <a href="https://github.com/revsapace/cipherlist.eu" >here</a>.
+		    Feedback <a href="https://github.com/revspace/cipherlist.eu/issues">here please</a>. Source code <a href="https://github.com/revspace/cipherlist.eu" >here</a>.
             <div class="row" style="clear: both;">
                 <div class="col-md-4 column">
                 <h3>Tweet</h3>

--- a/index.html
+++ b/index.html
@@ -118,12 +118,6 @@ add_header X-XSS-Protection "1; mode=block";
             <div class="col-md-4 column">
             <h2>Lighttpd</h2>
                 <pre class="pre-trans" id="lighttpdconfig">
-ssl.openssl.ssl-conf-cmd = (
-  "MinProtocol" =&gt; "TLSv1.2",
-  "Options" =&gt; "-ServerPreference",
-  "CipherString" =&gt; "EECDH+AESGCM:EDH+AESGCM:CHACHA20:!SHA1:!SHA256:!SHA384"
-)
-
 var.response_header_policy = (
   "strict-transport-security" =&gt; "max-age=63072000; includeSubDomains; preload",
   "content-security-policy" =&gt; "default-src https:",


### PR DESCRIPTION
    lighttpd: prefer lighttpd strong TLS defaults
    
    Since lighttpd 1.4.68, released Jan 2023 (over a year ago), TLS defaults
    in lighttpd are at least as strong as cipherlist.eu recommendations.
    
    For those setting up new lighttpd instances and referencing
    cipherlist.eu for new configs, the lighttpd TLS defaults are strongly
    recommended, as the lighttpd TLS defaults are periodically reviewed
    and updated to be stronger.
    
    Case in point, the next release of lighttpd will be lighttpd 1.4.75
    and will include TLS defaults that are stronger than those currently
    recommended on cipherlist.eu.
    
    Anyone using older versions of lighttpd *and* referencing cipherlist.eu
    for new configs for very old releases of lighttpd -- or very old
    releases of other servers -- probably ought to be directed to
    https://ssl-config.mozilla.org/ for configuring older server versions.